### PR TITLE
Add service tests with H2 database

### DIFF
--- a/microservice-compra/pom.xml
+++ b/microservice-compra/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microservice-compra/src/test/java/com/example/compra/CompraServiceTests.java
+++ b/microservice-compra/src/test/java/com/example/compra/CompraServiceTests.java
@@ -1,0 +1,35 @@
+package com.example.compra;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CompraServiceTests {
+
+    @Autowired
+    private CompraService service;
+    @Autowired
+    private CompraRepository repository;
+
+    @Test
+    void registrarYObtenerCompra() {
+        Compra c = new Compra();
+        c.setFecha(LocalDate.now());
+        c.setTotal(50.0);
+        Compra guardada = service.guardar(c);
+        assertThat(guardada.getId()).isNotNull();
+
+        Compra obtenida = repository.findById(guardada.getId()).orElse(null);
+        assertThat(obtenida).isNotNull();
+        assertThat(obtenida.getTotal()).isEqualTo(50.0);
+
+        List<Compra> compras = service.listar();
+        assertThat(compras).extracting(Compra::getId).contains(guardada.getId());
+    }
+}

--- a/microservice-compra/src/test/resources/application.properties
+++ b/microservice-compra/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:compra;DB_CLOSE_DELAY=-1;MODE=MYSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/microservice-inventario/pom.xml
+++ b/microservice-inventario/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microservice-inventario/src/test/java/com/example/inventario/ProductoServiceTests.java
+++ b/microservice-inventario/src/test/java/com/example/inventario/ProductoServiceTests.java
@@ -1,0 +1,35 @@
+package com.example.inventario;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProductoServiceTests {
+
+    @Autowired
+    private ProductoService service;
+    @Autowired
+    private ProductoRepository repository;
+
+    @Test
+    void registrarYObtenerProducto() {
+        Producto p = new Producto();
+        p.setNombre("Prueba");
+        p.setPrecio(10.0);
+        p.setCantidad(2);
+        Producto guardado = service.guardar(p);
+        assertThat(guardado.getId()).isNotNull();
+
+        Producto obtenido = repository.findById(guardado.getId()).orElse(null);
+        assertThat(obtenido).isNotNull();
+        assertThat(obtenido.getNombre()).isEqualTo("Prueba");
+
+        List<Producto> productos = service.listar();
+        assertThat(productos).extracting(Producto::getId).contains(guardado.getId());
+    }
+}

--- a/microservice-inventario/src/test/resources/application.properties
+++ b/microservice-inventario/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:inventario;DB_CLOSE_DELAY=-1;MODE=MYSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- add integration tests for `ProductoService`
- add integration tests for `CompraService`
- configure H2 datasource for tests
- include H2 dependency for tests in microservices

## Testing
- `sh microservice-eureka/mvnw -f microservice-inventario/pom.xml test` *(fails: Maven could not be downloaded)*
- `sh microservice-eureka/mvnw -f microservice-compra/pom.xml test` *(fails: Maven could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6861f3c0b4ec832c858047672cdeb91c