### PR TITLE
Add H2 test dependencies and service tests

### DIFF
--- a/microservice-compra/pom.xml
+++ b/microservice-compra/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microservice-compra/src/test/java/com/example/compra/CompraServiceTest.java
+++ b/microservice-compra/src/test/java/com/example/compra/CompraServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.compra;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+class CompraServiceTest {
+
+    @Autowired
+    private CompraService service;
+
+    @Autowired
+    private CompraRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        Compra c1 = new Compra();
+        c1.setFecha(LocalDate.now());
+        c1.setTotal(100.0);
+        service.guardar(c1);
+
+        Compra c2 = new Compra();
+        c2.setFecha(LocalDate.now());
+        c2.setTotal(50.0);
+        service.guardar(c2);
+    }
+
+    @Test
+    void testListar() {
+        List<Compra> compras = service.listar();
+        assertEquals(2, compras.size());
+    }
+
+    @Test
+    void testGuardar() {
+        Compra compra = new Compra();
+        compra.setFecha(LocalDate.now());
+        compra.setTotal(70.0);
+        Compra saved = service.guardar(compra);
+        assertNotNull(saved.getId());
+        assertEquals(3, repository.count());
+    }
+
+    @Test
+    void testEliminar() {
+        Long id = service.listar().get(0).getId();
+        service.eliminar(id);
+        assertEquals(1, repository.count());
+    }
+}

--- a/microservice-inventario/pom.xml
+++ b/microservice-inventario/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microservice-inventario/src/test/java/com/example/inventario/ProductoServiceTest.java
+++ b/microservice-inventario/src/test/java/com/example/inventario/ProductoServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.inventario;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+class ProductoServiceTest {
+
+    @Autowired
+    private ProductoService service;
+
+    @Autowired
+    private ProductoRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        Producto p1 = new Producto();
+        p1.setNombre("Producto1");
+        p1.setPrecio(10.0);
+        p1.setCantidad(5);
+        service.guardar(p1);
+
+        Producto p2 = new Producto();
+        p2.setNombre("Producto2");
+        p2.setPrecio(15.0);
+        p2.setCantidad(3);
+        service.guardar(p2);
+    }
+
+    @Test
+    void testListar() {
+        List<Producto> productos = service.listar();
+        assertEquals(2, productos.size());
+    }
+
+    @Test
+    void testGuardar() {
+        Producto nuevo = new Producto();
+        nuevo.setNombre("Producto3");
+        nuevo.setPrecio(20.0);
+        nuevo.setCantidad(2);
+        Producto saved = service.guardar(nuevo);
+        assertNotNull(saved.getId());
+        assertEquals(3, repository.count());
+    }
+
+    @Test
+    void testEliminar() {
+        Long id = service.listar().get(0).getId();
+        service.eliminar(id);
+        assertEquals(1, repository.count());
+    }
+}


### PR DESCRIPTION
## Summary
- add H2 database to test scope for compra and inventario services
- add ProductoServiceTest with in-memory database
- add CompraServiceTest with in-memory database

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f6e29898832c8971aa19d985c853